### PR TITLE
build: Add MTK support

### DIFF
--- a/core/config.mk
+++ b/core/config.mk
@@ -566,6 +566,9 @@ endif
 # Rules for QCOM targets
 include $(BUILD_SYSTEM)/qcom_target.mk
 
+# Rules for MTK targets
+include $(BUILD_SYSTEM)/mtk_target.mk
+
 # ###############################################################
 # Set up final options.
 # ###############################################################

--- a/core/mtk_target.mk
+++ b/core/mtk_target.mk
@@ -1,0 +1,13 @@
+ifeq ($(BOARD_USES_MTK_HARDWARE),true)
+    mtk_flags := -DMTK_HARDWARE
+
+    TARGET_GLOBAL_CFLAGS += $(mtk_flags)
+    TARGET_GLOBAL_CPPFLAGS += $(mtk_flags)
+    CLANG_TARGET_GLOBAL_CFLAGS += $(mtk_flags)
+    CLANG_TARGET_GLOBAL_CPPFLAGS += $(mtk_flags)
+
+    2ND_TARGET_GLOBAL_CFLAGS += $(mtk_flags)
+    2ND_TARGET_GLOBAL_CPPFLAGS += $(mtk_flags)
+    2ND_CLANG_TARGET_GLOBAL_CFLAGS += $(mtk_flags)
+    2ND_CLANG_TARGET_GLOBAL_CPPFLAGS += $(mtk_flags)
+endif


### PR DESCRIPTION
When setting BOARD_USES_MTK_HARDWARE, a global MTK_HARDWARE define will
be available to all target modules.

Change-Id: Id2a2996139a31afb6eb37f7ee24202587cb4beb1
