### PR TITLE
build: Use compatibility DTB directory path for custom DTB tool builds

### DIFF
--- a/core/tasks/dt_image.mk
+++ b/core/tasks/dt_image.mk
@@ -18,8 +18,13 @@ DTBTOOL := $(HOST_OUT_EXECUTABLES)/$(DTBTOOL_NAME)$(HOST_EXECUTABLE_SUFFIX)
 
 INSTALLED_DTIMAGE_TARGET := $(PRODUCT_OUT)/dt.img
 
-# Most specific paths must come first in possible_dtb_dirs
+ifeq ($(strip $(TARGET_CUSTOM_DTBTOOL)),)
+# dtbToolCM will search subdirectories
 possible_dtb_dirs = $(KERNEL_OUT)/arch/$(KERNEL_ARCH)/boot/
+else
+# Most specific paths must come first in possible_dtb_dirs
+possible_dtb_dirs = $(KERNEL_OUT)/arch/$(KERNEL_ARCH)/boot/dts/ $(KERNEL_OUT)/arch/$(KERNEL_ARCH)/boot/
+endif
 dtb_dir = $(firstword $(wildcard $(possible_dtb_dirs)))
 
 define build-dtimage-target


### PR DESCRIPTION
- dtbToolCM is able to search subdirectories, but we are not guaranteed
  that other dtbTool binaries have the same capability. Re-specify
  multiple paths for non-dtbToolCM builds just in case.

Change-Id: Id69e000af5eba60a07662b178cb95950451efd17
